### PR TITLE
waffle.io Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Stories in Ready](https://badge.waffle.io/leondeng/weight-track.png?label=ready&title=Ready)](https://waffle.io/leondeng/weight-track)
 <div>
 <a href="https://travis-ci.org/leondeng/weight-track">
 <img title="Build Status Images" src="https://travis-ci.org/leondeng/weight-track.svg">


### PR DESCRIPTION
Merge this to receive a badge indicating the number of issues in the ready column on your waffle.io board at https://waffle.io/leondeng/weight-track

This was requested by a real person (user leondeng) on waffle.io, we're not trying to spam you.
